### PR TITLE
Add addWatchFile method to plugin context

### DIFF
--- a/packages/vite/src/postcss-ver.ts
+++ b/packages/vite/src/postcss-ver.ts
@@ -288,6 +288,7 @@ export function stylex(options: StylexOptionsWithPostcss = {}): Plugin[] {
             const transformHook = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
             const ctx = {
               ...this,
+              addWatchFile: ()=>{},
               getCombinedSourcemap: () => {
                 throw new Error('getCombinedSourcemap not implemented')
               }


### PR DESCRIPTION
Motivation / Problem:
When using rolldown-vite instead of standard Vite, the build crashes with a TypeError: this.addWatchFile is not a function during the @stylex-extend/vite:build-css execution.

This occurs because the plugin manually calls Vite's CSS plugin transform hooks from inside the renderStart hook. Vite's CSS plugins expect a standard Build Phase context (which includes addWatchFile). While standard Rollup/Vite is forgiving and might still have this method available or silently ignore it, Rolldown is much stricter about its API boundaries and strips Build Phase methods from Output Phase contexts (like renderStart), causing the hard crash.

Solution:
Added a no-op addWatchFile: () => {} to the mock Rollup plugin context passed to the CSS plugins.

Why this is safe:
Because we are executing this inside renderStart, the build phase is already over, and the module graph is sealed. We don't actually need to watch any newly discovered files at this stage, so intercepting the call with an empty function safely fulfills the API contract Vite's CSS plugins expect without affecting the build output.

Testing:

[x] Verified standard vite build completes successfully.

[x] Verified rolldown-vite build completes without throwing the TypeError.